### PR TITLE
MOP-686: Removing location usage descriptions so they can be set in main config.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -48,18 +48,6 @@
         <source-file src="src/ios/Diagnostic_Location.m" />
 
         <framework src="CoreLocation.framework" />
-
-        <config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription" comment="Default usage descriptions: override as necessary in .plist">
-            <string>This app requires access to your location when the screen is on and the app is displayed.</string>
-        </config-file>
-
-        <config-file target="*-Info.plist" parent="NSLocationAlwaysAndWhenInUseUsageDescription" comment="iOS 11 or greater">
-            <string>This app requires constant access to your location in order to track your position, even when the screen is off or the app is in the background.</string>
-        </config-file>
-
-        <config-file target="*-Info.plist" parent="NSLocationAlwaysUsageDescription" comment="iOS 10 or below">
-            <string>This app requires constant access to your location in order to track your position, even when the screen is off or the app is in the background.</string>
-        </config-file>
         <!--END_MODULE LOCATION-->
 
         <!--BEGIN_MODULE BLUETOOTH-->


### PR DESCRIPTION
Removing location usage descriptions so they can be set in main config.xml